### PR TITLE
docs: update CLI references from `add-skill` to `skills`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Portable skills for AI coding assistants providing integrations with Jira, Confl
 ## Features
 
 - **Self-Contained**: Each skill is a single Python script - no framework dependencies
-- **Multi-Agent Compatible**: Works with [multiple AI coding assistants](https://github.com/vercel-labs/add-skill#supported-agents) including [Claude Code](https://claude.com/claude-code), Cursor, Continue.dev, and more
+- **Multi-Agent Compatible**: Works with [multiple AI coding assistants](https://github.com/vercel-labs/skills#supported-agents) including [Claude Code](https://claude.com/claude-code), Cursor, Continue.dev, and more
 - **Simple Installation**: Just Python + 3 packages (`requests`, `keyring`, `pyyaml`)
 - **Built-in Validation**: Each skill includes a `check` command for setup verification
 - **Secure Authentication**: Supports system keyring, environment variables, and config files
@@ -14,17 +14,17 @@ Portable skills for AI coding assistants providing integrations with Jira, Confl
 
 ### Installation (Recommended)
 
-Install skills using the official `add-skill` CLI:
+Install skills using the official `skills` CLI:
 
 ```bash
 # Install all skills
-npx add-skill odyssey4me/agent-skills
+npx skills add odyssey4me/agent-skills
 
 # Or install a specific skill
-npx add-skill odyssey4me/agent-skills --skill confluence
+npx skills add odyssey4me/agent-skills --skill confluence
 
 # Or install multiple specific skills
-npx add-skill odyssey4me/agent-skills --skill gmail --skill google-calendar
+npx skills add odyssey4me/agent-skills --skill gmail --skill google-calendar
 ```
 
 This automatically:
@@ -67,7 +67,7 @@ Want to contribute or modify skills? See [CONTRIBUTING.md](CONTRIBUTING.md) for 
 
 Browse install counts and popularity on [skills.sh](https://skills.sh/odyssey4me/agent-skills). Skills are also available on the [Tessl Registry](https://tessl.io/registry/odyssey4me). See [TODO.md](TODO.md) for planned skills.
 
-**Installation**: Use `npx add-skill odyssey4me/agent-skills` to install all skills, or see individual SKILL.md files for details. Manual downloads available from [Releases](https://github.com/odyssey4me/agent-skills/releases).
+**Installation**: Use `npx skills add odyssey4me/agent-skills` to install all skills, or see individual SKILL.md files for details. Manual downloads available from [Releases](https://github.com/odyssey4me/agent-skills/releases).
 
 ## Why Skills?
 
@@ -78,11 +78,11 @@ Skills provide a simple, transparent approach to extending Claude Code:
 - **Self-Validating**: Built-in `check` command diagnoses setup issues
 - **Portable**: Follows the [Agent Skills specification](https://agentskills.io/specification) for cross-agent compatibility
 
-This repository follows the Agent Skills spec, ensuring compatibility with `npx add-skill` and other standard tooling.
+This repository follows the Agent Skills spec, ensuring compatibility with `npx skills` and other standard tooling.
 
 ## Supported AI Agents
 
-These skills work with [multiple AI coding assistants](https://github.com/vercel-labs/add-skill#supported-agents) through the [Agent Skills specification](https://agentskills.io/specification), including:
+These skills work with [multiple AI coding assistants](https://github.com/vercel-labs/skills#supported-agents) through the [Agent Skills specification](https://agentskills.io/specification), including:
 
 - **Claude Code** - Anthropic's official CLI
 - **Cursor** - AI-first code editor
@@ -90,7 +90,7 @@ These skills work with [multiple AI coding assistants](https://github.com/vercel
 - **GitHub Copilot** - GitHub's AI pair programmer
 - **OpenCode**, **Gemini CLI**, **Command Code**, and more
 
-See the [full list of supported agents](https://github.com/vercel-labs/add-skill#supported-agents). Installation via `npx add-skill` automatically configures skills for your AI agent.
+See the [full list of supported agents](https://github.com/vercel-labs/skills#supported-agents). Installation via `npx skills add` automatically configures skills for your AI agent.
 
 ## Contributing
 

--- a/docs/config-samples/README.md
+++ b/docs/config-samples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains sample configuration files for Claude Code.
 
-> **Note**: These samples are for Claude Code. Skills work with [multiple AI agents](https://github.com/vercel-labs/add-skill#supported-agents) via the Agent Skills specification. See [../user-guide.md](../user-guide.md) for multi-agent installation.
+> **Note**: These samples are for Claude Code. Skills work with [multiple AI agents](https://github.com/vercel-labs/skills#supported-agents) via the Agent Skills specification. See [../user-guide.md](../user-guide.md) for multi-agent installation.
 
 ## Available Samples
 
@@ -12,7 +12,7 @@ This directory contains sample configuration files for Claude Code.
 
 ## When to Use This
 
-After installing skills with `npx add-skill odyssey4me/agent-skills`, you may want to configure Claude Code to make skills easier to discover and use. (These config samples are Claude Code-specific, but skills work with multiple AI agents.) The sample configuration:
+After installing skills with `npx skills add odyssey4me/agent-skills`, you may want to configure Claude Code to make skills easier to discover and use. (These config samples are Claude Code-specific, but skills work with multiple AI agents.) The sample configuration:
 
 1. Documents which skills are available
 2. Shows how to invoke skills (via `/jira` commands or natural language)
@@ -31,6 +31,6 @@ After installing skills with `npx add-skill odyssey4me/agent-skills`, you may wa
 
 ## Notes
 
-- The sample assumes skills were installed with `npx add-skill` to `~/.claude/skills`
+- The sample assumes skills were installed with `npx skills add` to `~/.claude/skills`
 - If you installed to a custom location, update the paths in CLAUDE.md
 - See [../user-guide.md](../user-guide.md) for complete installation instructions

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -592,16 +592,16 @@ Use `dev-link.sh` to redirect Claude Code's skill symlinks to your local checkou
 
 See [CONTRIBUTING.md - Local Skill Testing](../CONTRIBUTING.md#local-skill-testing) for more details.
 
-### Testing with npx add-skill
+### Testing with npx skills
 
 Verify compatibility with the installation tool:
 
 ```bash
 # List skills (should show your skill)
-npx add-skill odyssey4me/agent-skills --list
+npx skills add odyssey4me/agent-skills --list
 
 # Install skill
-npx add-skill odyssey4me/agent-skills --skill myskill
+npx skills add odyssey4me/agent-skills --skill myskill
 
 # Verify installation
 ls ~/.claude/skills/myskill
@@ -628,7 +628,7 @@ ls ~/.claude/skills/myskill
 
 ### Tools
 
-- **[add-skill CLI](https://github.com/vercel-labs/add-skill)** - Installation tool
+- **[skills CLI](https://github.com/vercel-labs/skills)** - Installation tool
   - How skill discovery works
   - Installation process
   - Symlink mode
@@ -652,7 +652,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for:
 - Read the [Agent Skills specification](https://agentskills.io/specification)
 - Review existing skills ([Jira](../skills/jira/SKILL.md), [Confluence](../skills/confluence/SKILL.md), [Gmail](../skills/gmail/SKILL.md))
 - Copy the template and start building
-- Test with `npx add-skill` for compatibility
+- Test with `npx skills` for compatibility
 - Submit a pull request
 
 For questions, [open an issue on GitHub](https://github.com/odyssey4me/agent-skills/issues).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -18,34 +18,34 @@ Learn more: [Progressive Disclosure in the Agent Skills Spec](https://agentskill
 
 ### Multi-Agent Compatibility
 
-Agent skills work with [multiple AI coding assistants](https://github.com/vercel-labs/add-skill#supported-agents) through the [Agent Skills specification](https://agentskills.io/specification). When you install skills using `npx add-skill`, they're automatically configured for your AI agent:
+Agent skills work with [multiple AI coding assistants](https://github.com/vercel-labs/skills#supported-agents) through the [Agent Skills specification](https://agentskills.io/specification). When you install skills using `npx skills add`, they're automatically configured for your AI agent:
 
 **Supported AI Agents:**
-- Claude Code, Cursor, Continue.dev, GitHub Copilot, OpenCode, Gemini CLI, Command Code, and [more](https://github.com/vercel-labs/add-skill#supported-agents)
+- Claude Code, Cursor, Continue.dev, GitHub Copilot, OpenCode, Gemini CLI, Command Code, and [more](https://github.com/vercel-labs/skills#supported-agents)
 
 **Agent-Specific Installation:**
 ```bash
 # Install for specific agent (optional, auto-detects by default)
-npx add-skill odyssey4me/agent-skills --skill gitlab -a cursor
+npx skills add odyssey4me/agent-skills --skill gitlab -a cursor
 
 # Install for multiple agents
-npx add-skill odyssey4me/agent-skills --skill gitlab -a claude-code -a cursor
+npx skills add odyssey4me/agent-skills --skill gitlab -a claude-code -a cursor
 ```
 
 The examples in this guide use Claude Code, but the same natural language patterns and commands work across all supported AI agents.
 
 ## Installation
 
-### Option 1: Using npx add-skill (Recommended)
+### Option 1: Using npx skills (Recommended)
 
-The fastest way to install skills is using the official `add-skill` CLI tool:
+The fastest way to install skills is using the official `skills` CLI tool:
 
 ```bash
 # Install a specific skill
-npx add-skill odyssey4me/agent-skills --skill jira
+npx skills add odyssey4me/agent-skills --skill jira
 
 # Install multiple skills
-npx add-skill odyssey4me/agent-skills --skill google-docs --skill google-sheets
+npx skills add odyssey4me/agent-skills --skill google-docs --skill google-sheets
 ```
 
 This will:
@@ -53,7 +53,7 @@ This will:
 - Install them to `~/.claude/skills/`
 - Make them available to your AI coding assistant automatically
 
-Learn more: [add-skill CLI documentation](https://github.com/vercel-labs/add-skill)
+Learn more: [skills CLI documentation](https://github.com/vercel-labs/skills)
 
 ### Option 2: Manual Installation
 
@@ -188,7 +188,7 @@ The check command will:
 
 Once installed and configured, skills are automatically available to your AI coding assistant.
 
-Skills work with [multiple AI coding assistants](https://github.com/vercel-labs/add-skill#supported-agents). The examples below use Claude Code, but the same patterns apply to other agents like Cursor, Continue.dev, and GitHub Copilot.
+Skills work with [multiple AI coding assistants](https://github.com/vercel-labs/skills#supported-agents). The examples below use Claude Code, but the same patterns apply to other agents like Cursor, Continue.dev, and GitHub Copilot.
 
 ### Natural Language Invocation
 
@@ -393,7 +393,7 @@ Found a bug or have a feature request? [Open an issue on GitHub](https://github.
 ## References
 
 - [Agent Skills Specification](https://agentskills.io/specification) - Official standard
-- [add-skill CLI](https://github.com/vercel-labs/add-skill) - Installation tool
+- [skills CLI](https://github.com/vercel-labs/skills) - Installation tool
 - [Vercel agent-skills](https://github.com/vercel-labs/agent-skills) - Reference implementation
 - [Anthropic skills](https://github.com/anthropics/skills) - Additional examples
 


### PR DESCRIPTION
The `add-skill` npm package has been renamed to `skills`. This PR updates all documentation to use the new `npx skills add` command syntax and points GitHub links to `vercel-labs/skills` instead of `vercel-labs/add-skill`.

**Changes across 4 files:**
- `npx add-skill` → `npx skills add` (CLI invocations)
- `add-skill` CLI name → `skills` CLI name  
- `vercel-labs/add-skill` → `vercel-labs/skills` (GitHub repo URLs)

Closes #6